### PR TITLE
Added Key processing, CIA Content Offset tracking, etc

### DIFF
--- a/SabreTools.Models/N3DS/AESKeys.cs
+++ b/SabreTools.Models/N3DS/AESKeys.cs
@@ -1,0 +1,104 @@
+namespace SabreTools.Models.N3DS
+{
+    #region Standard 3DS Keys
+
+    public class Keys
+    {
+        /// <summary>
+        /// AES Hardware Constant
+        /// </summary>
+        public byte[]? AESHardwareConstant { get; private set; }
+
+        /// <summary>
+        /// KeyX 0x18 (New 3DS 9.3)
+        /// </summary>
+        public byte[]? KeyX0x18 { get; private set; }
+
+        /// <summary>
+        /// Dev KeyX 0x18 (New 3DS 9.3)
+        /// </summary>
+        public byte[]? DevKeyX0x18 { get; private set; }
+
+        /// <summary>
+        /// KeyX 0x1B (New 3DS 9.6)
+        /// </summary>
+        public byte[]? KeyX0x1B { get; private set; }
+
+        /// <summary>
+        /// Dev KeyX 0x1B (New 3DS 9.6)
+        /// </summary>
+        public byte[]? DevKeyX0x1B { get; private set; }
+
+        /// <summary>
+        /// KeyX 0x25 (> 7.x)
+        /// </summary>
+        public byte[]? KeyX0x25 { get; private set; }
+
+        /// <summary>
+        /// Dev KeyX 0x25 (> 7.x)
+        /// </summary>
+        public byte[]? DevKeyX0x25 { get; private set; }
+
+        /// <summary>
+        /// KeyX 0x2C (< 6.x)
+        /// </summary>
+        public byte[]? KeyX0x2C { get; private set; }
+
+        /// <summary>
+        /// Dev KeyX 0x2C (< 6.x)
+        /// </summary>
+        public byte[]? DevKeyX0x2C { get; private set; }
+
+        #endregion
+
+        #region Extended Keys for CIA Decryption
+
+        /// <summary>
+        /// KeyX 0x3D (Common Key)
+        /// </summary>
+        public byte[]? KeyX03D { get; private set; }
+
+        /// <summary>
+        /// Dev KeyX 0x3D (Common Key)
+        /// </summary>
+        public byte[]? DevKeyX03D { get; private set; }
+
+        /// <summary>
+        /// KeyX 0x3B (CTR Card hardware crypto seed)
+        /// </summary>
+        public byte[]? KeyX03B { get; private set; }
+
+        /// <summary>
+        /// Dev KeyX 0x3B (CTR Card hardware crypto seed)
+        /// </summary>
+        public byte[]? DevKeyX03B { get; private set; }
+
+        #endregion
+
+        #region AES KeyY0x3D keys
+
+        /// <summary>
+        /// AES KeyY 0x3D array (Common Key)
+        /// </summary>
+        public byte[][]? AESKeyY0x3D { get; private set; }
+
+        /// <summary>
+        /// Dev AES KeyY 0x3D array (Common Key)
+        /// </summary>
+        public byte[][]? DevAESKeyY0x3D { get; private set; }
+
+        #endregion
+
+        #region SeedDB Key
+
+        /// <summary>
+        /// SeedDB key
+        /// The SeedDB key is used for decrypting content that utilizes the SeedDB encryption method,
+        /// which is often employed in downloadable content and updates on the 3DS platform.
+        /// This key is not universal and may vary based on the specific content or title.
+        /// </summary>
+        public byte[]? SeedDBKey { get; private set; }
+
+        #endregion
+    }
+}

--- a/SabreTools.Models/N3DS/CIA.cs
+++ b/SabreTools.Models/N3DS/CIA.cs
@@ -15,6 +15,11 @@ namespace SabreTools.Models.N3DS
     public class CIA
     {
         /// <summary>
+        /// Offset records for each file in the CIA
+        /// </summary>
+        public List<CIAOffsets>? Offsets { get; set; }
+
+        /// <summary>
         /// CIA header
         /// </summary>
         public CIAHeader? Header { get; set; }

--- a/SabreTools.Models/N3DS/CIAOffsets.cs
+++ b/SabreTools.Models/N3DS/CIAOffsets.cs
@@ -1,0 +1,24 @@
+namespace SabreTools.Models.N3DS
+{
+    /// <summary>
+    /// Offsets for each file in the CIA
+    /// </summary>
+    public class CIAOffsets
+    {
+        /// <summary>
+        /// Offset to each item in the CIA
+        /// </summary>
+        public ulong Offset { get; set; }
+
+        /// <summary>
+        /// Item Type
+        /// Lets the user keep track of what each offset is for
+        /// </summary>
+        public ItemTypes ItemType { get; set; }
+
+        /// <summary>
+        /// Size of each item in the CIA
+        /// </summary>
+        public ulong Size { get; set; }
+    }
+}

--- a/SabreTools.Models/N3DS/Enums.cs
+++ b/SabreTools.Models/N3DS/Enums.cs
@@ -226,4 +226,19 @@ namespace SabreTools.Models.N3DS
         Optional = 0x4000,
         Shared = 0x8000,
     }
+
+    /// <summary>
+    /// Item types for each file in the CIA
+    /// Used to track what item is at each offset
+    /// With many CIAs having multiple Content files.
+    /// </summary>
+    public enum ItemTypes
+    {
+        Header = 0x00,
+        CertChain = 0x01,
+        Ticket = 0x02,
+        TMD = 0x03,
+        Content = 0x04,
+        Meta = 0x05,
+    }
 }


### PR DESCRIPTION
Added placeholders for AES keys to decouple from NDecrypt.
Added CIA offsets and item types because CIAs do not have a partition table. Using that to get the offsets of each item, ie TMD, Header, NCCH, etc, and their sizes and types to make data seeking easier.