### PR TITLE
AACS2 support

### DIFF
--- a/SabreTools.Models/AACS/Enums.cs
+++ b/SabreTools.Models/AACS/Enums.cs
@@ -31,12 +31,14 @@ namespace SabreTools.Models.AACS
         /// <summary>
         /// Type 2.0 Category C.
         /// This is the Media Key Block Type found on "UHD" media (AACS v2.0)
+        /// https://code.videolan.org/videolan/libaacs/-/blob/master/src/libaacs/mkb.h
         /// </summary>
         Type20 = 0x48141003,
 
         /// <summary>
         /// Type 2.1 Category C.
         /// This is the Media Key Block Type found on "UHD" media (AACS v2.1)
+        /// https://code.videolan.org/videolan/libaacs/-/blob/master/src/libaacs/mkb.h
         /// </summary>
         Type21 = 0x48151003,
     }
@@ -57,6 +59,7 @@ namespace SabreTools.Models.AACS
         Copyright = 0x7F,
 
         // Record types only found in UHD media (AACS v2)
+        // https://code.videolan.org/videolan/libaacs/-/blob/master/src/devtools/mkb_dump.c
         Unknown0x28_AACS2 = 0x28,
         DriveRevocationList_AACS2 = 0x30,
         HostRevocationList_AACS2 = 0x31,


### PR DESCRIPTION
This adds AACS v2 support to Models.

I have inspected multiple media key blocks from UHD discs for this purpose (from MKB 60 to 77). They all have 0x48141003 and consistently use the all the new record types I have added.

Intended to fix https://github.com/SabreTools/BinaryObjectScanner/issues/291